### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM ubuntu
-RUN apt-get update
-RUN apt-get install apt-transport-https wget -y
-RUN mkdir -p /home/prod
-RUN cd /home/prod
-RUN wget http://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
-RUN dpkg -i packages-microsoft-prod.deb
-RUN apt-get update
-RUN apt-get upgrade
-RUN apt-get install aptitude -y
-RUN aptitude install microsoft-mlserver-all-9.2.1 -y
-RUN ls -la /etc/apt/sources.list.d/
-RUN bash /opt/microsoft/mlserver/9.2.1/bin/R/activate.sh
+FROM ubuntu:16.04
+ENV MLSERVER_VERSION=9.2.1
+RUN apt-key adv --keyserver pgp.mit.edu --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF \
+    && apt-get update \
+    && apt-get install -y apt-transport-https \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/16.04/prod xenial main" > /etc/apt/sources.list.d/microsoft-prod.list \
+    && apt-get update \
+    && apt-get install -y microsoft-mlserver-all-$MLSERVER_VERSION \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && /opt/microsoft/mlserver/$MLSERVER_VERSION/bin/R/activate.sh


### PR DESCRIPTION
- Fewer layers, single RUN
- Remove microsoft-prod.deb download and install because it isn't signed
- Add trusted Microsoft GPG key from keyserver and apt source manually
- Clean up after apt